### PR TITLE
[#58] 가장 먼 노드 - 정답

### DIFF
--- a/ningpop/level3/가장_먼_노드.py
+++ b/ningpop/level3/가장_먼_노드.py
@@ -1,0 +1,44 @@
+# 2022.08.20
+# 풀이 시간: 23분 45초
+# 채점 결과: 정답
+# 시간복잡도: O(NlogM)
+# 문제 링크: https://school.programmers.co.kr/learn/courses/30/lessons/49189
+
+import heapq
+
+INF = int(1e9)
+
+def dijkstra(start: int, graph: list, distance: list):
+    q = []
+    heapq.heappush(q, (0, start))
+    distance[start] = 0
+    
+    while q:
+        dist, now = heapq.heappop(q)
+        if distance[now] < dist:
+            continue
+        for i in graph[now]:
+            cost = dist + i[1]
+            if cost < distance[i[0]]:
+                distance[i[0]] = cost
+                heapq.heappush(q, (cost, i[0]))
+    
+
+def solution(n: int, edge: list) -> int:
+
+    graph = [[] for i in range(n + 1)]
+    distance = [INF] * (n + 1)
+
+    for a, b in edge:
+        graph[a].append((b, 1))
+        graph[b].append((a, 1))
+    
+    dijkstra(1, graph, distance)
+    
+    result = [ i for i in distance[2:] if i != 1e9 ]
+    maximum = max(result)
+    answer = result.count(maximum)
+
+    return answer
+
+print(solution(6, [[3, 6], [4, 3], [3, 2], [1, 3], [1, 2], [2, 4], [5, 2]])) # 3


### PR DESCRIPTION
## 문제 이름
<!-- 문제 이름을 적어주세요. ex.) 신고 결과 받기 -->
<!-- 문제에 대한 이슈를 생성하였다면 이슈번호와 함께 이슈를 닫아주세요. ex.) closed #01 -->
closed #58 

## 풀이 사항
<!-- 어떻게 풀이했는지 아래의 정보를 적어주세요. -->
- 풀이 일자: 2022.08.20
- 풀이 시간: 23분 45초
- 채점 결과: 정답
- 시간복잡도: O(NlogM)
- 문제 링크: https://school.programmers.co.kr/learn/courses/30/lessons/49189

## 기타 특이 사항
<!-- 문제를 풀면서 있었던 특이 사항들을 적어주세요. -->
<!-- ex.) 접근방식을 잘못 접근해 풀이시간을 길게 사용하였습니다. -->
우선순위 큐를 사용한 다익스트라 기법을 사용하였습니다. 다익스트라 알고리즘으로 1번 노드로부터의 최단거리 테이블을 만든 후, `INF` 최댓값 제거하고 난 상태의 최댓값의 개수를 세어 반환하였고, 정답 처리 되었습니다.